### PR TITLE
Extract config parsing into pkg/config

### DIFF
--- a/cmd/breakpoint/wait.go
+++ b/cmd/breakpoint/wait.go
@@ -6,20 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/muesli/reflow/wordwrap"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/metadata"
-	internalv1 "namespacelabs.dev/breakpoint/api/private/v1"
-	v1 "namespacelabs.dev/breakpoint/api/public/v1"
-	"namespacelabs.dev/breakpoint/pkg/github"
-	"namespacelabs.dev/breakpoint/pkg/githuboidc"
+	"namespacelabs.dev/breakpoint/pkg/config"
 	"namespacelabs.dev/breakpoint/pkg/internalserver"
-	"namespacelabs.dev/breakpoint/pkg/jsonfile"
 	"namespacelabs.dev/breakpoint/pkg/passthrough"
 	"namespacelabs.dev/breakpoint/pkg/quicproxyclient"
 	"namespacelabs.dev/breakpoint/pkg/sshd"
@@ -36,16 +29,16 @@ func newWaitCmd() *cobra.Command {
 		Short: "Blocks for the duration of the breakpoint",
 	}
 
-	config := cmd.Flags().String("config", "", "Path to the configuration file.")
+	configPath := cmd.Flags().String("config", "", "Path to the configuration file.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if *config == "" {
+		if *configPath == "" {
 			return errors.New("--config is required")
 		}
 
 		ctx := cmd.Context()
 
-		cfg, err := loadConfig(ctx, *config)
+		cfg, err := config.LoadConfig(ctx, *configPath)
 		if err != nil {
 			return err
 		}
@@ -118,88 +111,6 @@ func newWaitCmd() *cobra.Command {
 	}
 
 	return cmd
-}
-
-func loadConfig(ctx context.Context, file string) (ParsedConfig, error) {
-	var cfg ParsedConfig
-	if err := jsonfile.Load(file, &cfg.WaitConfig); err != nil {
-		return cfg, err
-	}
-
-	for _, wh := range cfg.Webhooks {
-		if wh.URL == "" {
-			return cfg, errors.New("webhook is missing url")
-		}
-	}
-
-	if len(cfg.Shell) == 0 {
-		if sh, ok := os.LookupEnv("SHELL"); ok {
-			cfg.Shell = []string{sh}
-		} else {
-			cfg.Shell = []string{"/bin/sh"}
-		}
-	}
-
-	requireGitHubOIDC := false
-	for _, feature := range cfg.Enable {
-		switch feature {
-		case "github/oidc":
-			// Force enable.
-			requireGitHubOIDC = false
-
-		default:
-			return cfg, fmt.Errorf("unknown feature %q", feature)
-		}
-	}
-
-	cfg.RegisterMetadata = metadata.MD{}
-	if githuboidc.OIDCAvailable() || requireGitHubOIDC {
-		token, err := githuboidc.JWT(ctx, v1.GitHubOIDCAudience)
-		if err != nil {
-			if requireGitHubOIDC {
-				return cfg, err
-			}
-
-			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to obtain GitHUB OIDC token")
-		} else {
-			cfg.RegisterMetadata[v1.GitHubOIDCTokenHeader] = []string{token.Value}
-		}
-	}
-
-	dur, err := time.ParseDuration(cfg.Duration)
-	if err != nil {
-		return cfg, err
-	}
-
-	cfg.ParsedDuration = dur
-
-	keyMap, err := github.ResolveSSHKeys(ctx, cfg.AuthorizedGithubUsers)
-	if err != nil {
-		return cfg, err
-	}
-
-	revIndex := map[string]string{}
-
-	for _, key := range cfg.AuthorizedKeys {
-		revIndex[key] = key
-	}
-
-	for user, keys := range keyMap {
-		for _, key := range keys {
-			revIndex[key] = user
-		}
-	}
-
-	cfg.AllKeys = revIndex
-	return cfg, nil
-}
-
-type ParsedConfig struct {
-	internalv1.WaitConfig
-
-	AllKeys          map[string]string // Key ID -> Owned name
-	ParsedDuration   time.Duration
-	RegisterMetadata metadata.MD
 }
 
 func cancelIsOK(err error) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,10 @@ func LoadConfig(ctx context.Context, file string) (ParsedConfig, error) {
 		return cfg, err
 	}
 
+	if cfg.Endpoint == "" {
+		return cfg, errors.New("missing endpoint")
+	}
+
 	for _, wh := range cfg.Webhooks {
 		if wh.URL == "" {
 			return cfg, errors.New("webhook is missing url")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/metadata"
+	internalv1 "namespacelabs.dev/breakpoint/api/private/v1"
+	"namespacelabs.dev/breakpoint/api/public/v1"
+	"namespacelabs.dev/breakpoint/pkg/github"
+	"namespacelabs.dev/breakpoint/pkg/githuboidc"
+	"namespacelabs.dev/breakpoint/pkg/jsonfile"
+)
+
+func LoadConfig(ctx context.Context, file string) (ParsedConfig, error) {
+	var cfg ParsedConfig
+	if err := jsonfile.Load(file, &cfg.WaitConfig); err != nil {
+		return cfg, err
+	}
+
+	for _, wh := range cfg.Webhooks {
+		if wh.URL == "" {
+			return cfg, errors.New("webhook is missing url")
+		}
+	}
+
+	if len(cfg.Shell) == 0 {
+		if sh, ok := os.LookupEnv("SHELL"); ok {
+			cfg.Shell = []string{sh}
+		} else {
+			cfg.Shell = []string{"/bin/sh"}
+		}
+	}
+
+	requireGitHubOIDC := false
+	for _, feature := range cfg.Enable {
+		switch feature {
+		case "github/oidc":
+			// Force enable.
+			requireGitHubOIDC = false
+
+		default:
+			return cfg, fmt.Errorf("unknown feature %q", feature)
+		}
+	}
+
+	cfg.RegisterMetadata = metadata.MD{}
+	if githuboidc.OIDCAvailable() || requireGitHubOIDC {
+		token, err := githuboidc.JWT(ctx, v1.GitHubOIDCAudience)
+		if err != nil {
+			if requireGitHubOIDC {
+				return cfg, err
+			}
+
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to obtain GitHUB OIDC token")
+		} else {
+			cfg.RegisterMetadata[v1.GitHubOIDCTokenHeader] = []string{token.Value}
+		}
+	}
+
+	dur, err := time.ParseDuration(cfg.Duration)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.ParsedDuration = dur
+
+	keyMap, err := github.ResolveSSHKeys(ctx, cfg.AuthorizedGithubUsers)
+	if err != nil {
+		return cfg, err
+	}
+
+	revIndex := map[string]string{}
+
+	for _, key := range cfg.AuthorizedKeys {
+		revIndex[key] = key
+	}
+
+	for user, keys := range keyMap {
+		for _, key := range keys {
+			revIndex[key] = user
+		}
+	}
+
+	cfg.AllKeys = revIndex
+	return cfg, nil
+}
+
+type ParsedConfig struct {
+	internalv1.WaitConfig
+
+	AllKeys          map[string]string // Key ID -> Owned name
+	ParsedDuration   time.Duration
+	RegisterMetadata metadata.MD
+}

--- a/pkg/waiter/output.go
+++ b/pkg/waiter/output.go
@@ -1,0 +1,46 @@
+package waiter
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/muesli/reflow/wordwrap"
+)
+
+func PrintConnectionInfo(status ManagerStatus, output io.Writer) {
+	host, port, _ := net.SplitHostPort(status.Endpoint)
+	deadline := status.Expiration
+
+	if host == "" && port == "" {
+		return
+	}
+
+	ww := wordwrap.NewWriter(80)
+	fmt.Fprintf(ww, "Breakpoint! Running until %v (%v).", deadline.Format(Stamp), humanize.Time(deadline))
+	_ = ww.Close()
+
+	lines := strings.Split(ww.String(), "\n")
+
+	longestLine := 0
+	for _, l := range lines {
+		if len(l) > longestLine {
+			longestLine = len(l)
+		}
+	}
+
+	longline := nchars('─', longestLine)
+	spaces := nchars(' ', longestLine)
+	fmt.Fprintln(output)
+	fmt.Fprintf(output, "┌─%s─┐\n", longline)
+	for _, l := range lines {
+		fmt.Fprintf(output, "│ %s%s │\n", l, spaces[len(l):])
+	}
+	fmt.Fprintf(output, "└─%s─┘\n", longline)
+	fmt.Fprintln(output)
+
+	fmt.Fprintf(output, "Connect with:\n\n")
+	fmt.Fprintf(output, "ssh -p %s runner@%s\n", port, host)
+}


### PR DESCRIPTION
In preparation for adding new features, extract some logic into separate function so they can be re-used.

<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nochangelog: Extract config parsing into pkg/config

<br>

#### nochangelog: Extract printing connection instructions to a separate function

<br>

#### config: Require an endpoint to be present in the configuration file
<!-- pr-cli body end -->